### PR TITLE
fixes pokemon search functionality

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,6 @@ import { useEffect, useState } from "react";
 import { fetchAllPokemon } from "./api";
 
 function App() {
-    const [pokemonIndex, setPokemonIndex] = useState([])
     const [pokemon, setPokemon] = useState([])
     const [searchValue, setSearchValue] = useState('')
     const [pokemonDetails, setPokemonDetails] = useState()
@@ -11,8 +10,11 @@ function App() {
         const fetchPokemon = async () => {
             const {results: pokemonList} = await fetchAllPokemon()
 
-            setPokemon(pokemonList)
-            setPokemonIndex(pokemonList)
+            setPokemon(
+                searchValue
+                    ? pokemonList.filter(monster => monster.name.includes(searchValue))
+                    : pokemonList
+            )
         }
 
         fetchPokemon().then(() => {
@@ -21,12 +23,8 @@ function App() {
     }, [searchValue])
 
     const onSearchValueChange = (event) => {
-        const value = event.target.value
+        const value = event.target.value.trim();
         setSearchValue(value)
-
-        setPokemon(
-            pokemonIndex.filter(monster => !monster.name.includes(value))
-        )
     }
 
     const onGetDetails = (name) => async () => {


### PR DESCRIPTION
Resolves #1 

## What Changed
This update fixes the pokemon search functionality by:
- trimming the user's input, so they cannot enter leading or trailing spaces. Since we are doing a direct sub-string comparison, these spaces were breaking the search.
- since there was no use-case requiring the use of both the filtered list and the full (original) list of pokemon, and we are requesting the full list on each search query change, this update removes the `pokemonIndex` array, and only sets the filtered list within the fetch response `fetchPokemon` response.